### PR TITLE
Add Latest Works section to landing page

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,8 @@
 const textContainer = document.getElementById('textContainer');
 const searchBox = document.getElementById('searchBox');
 const linkAntichrist = document.getElementById('link-antichrist');
+const latestWorksList = document.getElementById('latestWorksList');
+const headerEl = document.querySelector('header');
 const sidebar = document.getElementById('sidebar');
 const closeSidebar = document.getElementById('closeSidebar');
 const annotationView = document.getElementById('annotationView');
@@ -18,7 +20,33 @@ let docParagraphs = []; // [{id, text}]
 let annotations = [];   // [{id, pid, start, end, exact, prefix, suffix, body, tags, createdAt}]
 let currentSearchMatches = new Map(); // pid -> [{id, start, end}]
 
+if (latestWorksList) {
+  latestWorksList.addEventListener('click', (event) => {
+    const button = event.target.closest('button[data-work-id]');
+    if (!button) return;
+    event.preventDefault();
+    const workId = button.dataset.workId;
+    if (workId) activateWork(workId).catch(err => console.error(err));
+  });
+}
+
 const STORAGE_KEY = 'scholia_annotations_v1';
+
+const latestWorks = [
+  {
+    id: 'antichrist-1895-de',
+    title: 'Der Antichrist',
+    author: 'Friedrich Nietzsche',
+    year: 1895,
+    language: 'German',
+    src: 'antichrist_de_sample.txt',
+    description: 'Sample selection from the 1895 German publication prepared for the annotation demo.'
+  }
+];
+
+const worksIndex = new Map(latestWorks.map(work => [work.id, work]));
+let currentWorkId = null;
+const DEFAULT_WORK_ID = latestWorks[0]?.id || null;
 
 function loadAnnotations() {
   try {
@@ -41,6 +69,71 @@ async function loadText(url) {
   currentSearchMatches = new Map();
   if (searchBox) searchBox.value = '';
   renderText();
+}
+
+function renderLatestWorks() {
+  if (!latestWorksList) return;
+  const fragments = latestWorks.map(work => {
+    const meta = [work.author, work.year, work.language].filter(Boolean).join(' · ');
+    const description = work.description ? `<span class="latest-works__description">${escapeHtml(work.description)}</span>` : '';
+    const metaMarkup = meta ? `<span class="latest-works__meta">${escapeHtml(meta)}</span>` : '';
+    return `<li class="latest-works__item" data-work-id="${work.id}">
+      <button type="button" class="latest-works__link" data-work-id="${work.id}" aria-pressed="false">
+        <span class="latest-works__title">${escapeHtml(work.title)}</span>
+        ${metaMarkup}
+        ${description}
+      </button>
+    </li>`;
+  });
+  latestWorksList.innerHTML = fragments.join('');
+  refreshLayoutMetrics();
+}
+
+function updateActiveWorkUI(activeId) {
+  if (latestWorksList) {
+    const items = latestWorksList.querySelectorAll('.latest-works__item');
+    items.forEach(item => {
+      const workId = item.dataset.workId;
+      const isActive = workId === activeId;
+      item.classList.toggle('latest-works__item--active', isActive);
+      const button = item.querySelector('.latest-works__link');
+      if (button) button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+  }
+  if (linkAntichrist) {
+    const isActive = linkAntichrist.dataset.workId === activeId;
+    linkAntichrist.classList.toggle('is-active', isActive);
+  }
+}
+
+async function activateWork(workId, { skipIfSame = false } = {}) {
+  const work = worksIndex.get(workId);
+  if (!work) return;
+  if (skipIfSame && currentWorkId === workId) return;
+  if (linkAntichrist) {
+    linkAntichrist.textContent = `${work.author} — ${work.title}`;
+    linkAntichrist.dataset.src = work.src;
+    linkAntichrist.dataset.workId = work.id;
+  }
+  updateActiveWorkUI(workId);
+  try {
+    await loadText(work.src);
+    currentWorkId = workId;
+    updateActiveWorkUI(workId);
+  } catch (err) {
+    alert('Failed to load text: ' + err.message);
+    throw err;
+  } finally {
+    refreshLayoutMetrics();
+  }
+}
+
+function refreshLayoutMetrics() {
+  if (!headerEl) return;
+  const height = headerEl.offsetHeight;
+  if (height > 0) {
+    document.documentElement.style.setProperty('--header-height', `${height}px`);
+  }
 }
 
 function renderText() {
@@ -344,17 +437,32 @@ btnImport.addEventListener('click', async () => {
 // Utility
 function escapeHtml(s){return s.replace(/[&<>"']/g, m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[m]))}
 
-// Load sample on click
+// Load work via navigation link
 linkAntichrist.addEventListener('click', (e) => {
   e.preventDefault();
-  loadText(linkAntichrist.dataset.src).catch(err => alert('Failed to load text: '+err.message));
+  const workId = linkAntichrist.dataset.workId;
+  if (workId && worksIndex.has(workId)) {
+    activateWork(workId, { skipIfSame: true }).catch(err => console.error(err));
+  } else if (linkAntichrist.dataset.src) {
+    loadText(linkAntichrist.dataset.src).catch(err => alert('Failed to load text: ' + err.message));
+  }
 });
+
+window.addEventListener('resize', refreshLayoutMetrics);
+window.addEventListener('load', refreshLayoutMetrics);
 
 // Auto-load on first visit
 window.addEventListener('DOMContentLoaded', () => {
   loadAnnotations();
-  const src = linkAntichrist.dataset.src; // e.g., "antichrist_de_sample.txt" in same folder as index.html
-  loadText(src).catch(err => {
-    textContainer.textContent = 'Failed to load the sample text. Place a public-domain text file alongside index.html and set the link.';
-  });
+  renderLatestWorks();
+  if (DEFAULT_WORK_ID) {
+    activateWork(DEFAULT_WORK_ID).catch(err => {
+      textContainer.textContent = 'Failed to load the sample text. Place a public-domain text file alongside index.html and set the link.';
+      console.error(err);
+    });
+  } else if (linkAntichrist.dataset.src) {
+    loadText(linkAntichrist.dataset.src).catch(err => {
+      textContainer.textContent = 'Failed to load the sample text. Place a public-domain text file alongside index.html and set the link.';
+    });
+  }
 });

--- a/index.html
+++ b/index.html
@@ -8,15 +8,23 @@
 </head>
 <body>
   <header>
-    <div class="brand">Scholia</div>
-    <nav>
-      <a href="#" id="link-antichrist" data-src="antichrist_de_sample.txt">Nietzsche — Der Antichrist</a>
-      <button id="btn-import" title="Import annotations JSON">Import</button>
-      <button id="btn-export" title="Export annotations JSON">Export</button>
-    </nav>
+    <div class="header-top">
+      <div class="brand">Scholia</div>
+      <nav>
+        <a href="#" id="link-antichrist" data-src="antichrist_de_sample.txt" data-work-id="antichrist-1895-de">Nietzsche — Der Antichrist</a>
+        <button id="btn-import" title="Import annotations JSON">Import</button>
+        <button id="btn-export" title="Export annotations JSON">Export</button>
+      </nav>
+    </div>
     <div class="search">
       <input type="search" id="searchBox" placeholder="Search in text…" aria-label="Search in text"/>
     </div>
+    <section class="latest-works" aria-labelledby="latestWorksHeading">
+      <div class="latest-works__inner">
+        <h2 id="latestWorksHeading">Latest Works</h2>
+        <ul id="latestWorksList" class="latest-works__list" role="list"></ul>
+      </div>
+    </section>
   </header>
 
   <main>

--- a/styles.css
+++ b/styles.css
@@ -1,20 +1,42 @@
 *{box-sizing:border-box}html,body{margin:0;padding:0}
+:root{--header-height:68px}
 body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Arial,sans-serif;line-height:1.55}
-header{display:flex;gap:1rem;align-items:center;justify-content:space-between;padding:0.6rem 1rem;border-bottom:1px solid #ddd;position:sticky;top:0;background:#fff;z-index:10}
-.brand{font-weight:700}
-nav{display:flex;gap:0.6rem;align-items:center}
-nav a{color:#0a5; text-decoration:none; font-weight:600}
-nav a:hover{text-decoration:underline}
-header .search{flex:1;display:flex;justify-content:flex-end}
-#searchBox{width:min(520px,80vw);padding:0.45rem 0.6rem;border:1px solid #ccc;border-radius:6px}
+header{display:flex;flex-direction:column;gap:0.75rem;padding:0.75rem 1rem 1.1rem;border-bottom:1px solid #ddd;position:sticky;top:0;background:#fff;z-index:10}
+.header-top{display:flex;align-items:center;justify-content:space-between;gap:1rem}
+.brand{font-weight:700;font-size:1.2rem}
+nav{display:flex;gap:0.6rem;align-items:center;flex-wrap:wrap}
+nav a{color:#0a5;text-decoration:none;font-weight:600;transition:color .2s}
+nav a:hover{color:#097;text-decoration:underline}
+nav a.is-active{color:#07563d;text-decoration:underline}
+header .search{display:flex;justify-content:flex-end;width:100%}
+#searchBox{width:min(520px,100%);padding:0.45rem 0.6rem;border:1px solid #ccc;border-radius:6px}
+.latest-works{border-top:1px solid #eee;padding-top:0.75rem}
+.latest-works__inner{display:flex;flex-direction:column;gap:0.6rem}
+.latest-works__inner h2{margin:0;font-size:1.05rem;font-weight:600;color:#222}
+.latest-works__list{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:0.75rem;margin:0;padding:0;list-style:none}
+.latest-works__item{display:flex}
+.latest-works__item button{appearance:none;border:none;background:none;padding:0;margin:0;font:inherit}
+.latest-works__link{width:100%;text-align:left;border:1px solid #e2e2e2;border-radius:10px;padding:0.8rem 0.9rem;background:#fafafa;display:flex;flex-direction:column;gap:0.35rem;cursor:pointer;transition:border-color .2s,box-shadow .2s,transform .2s,background .2s}
+.latest-works__title{font-weight:600;font-size:1rem;color:#222}
+.latest-works__meta{font-size:0.9rem;color:#4e4e4e}
+.latest-works__description{font-size:0.85rem;color:#5a5a5a;line-height:1.4}
+.latest-works__link:hover,.latest-works__link:focus{border-color:#0a5;box-shadow:0 6px 18px rgba(0,0,0,.08);background:#fff;outline:none;transform:translateY(-1px)}
+.latest-works__item--active .latest-works__link{border-color:#0a5;background:#f0fff7;box-shadow:0 0 0 1px rgba(0,170,85,.2)}
 
-main{display:grid;grid-template-columns: 1fr 340px;gap:0;border-top:0}
-#reader{padding:1rem 1rem 4rem 1rem;max-width: 920px}
+@media (max-width:720px){
+  header{gap:0.65rem;padding:0.65rem 0.9rem 1rem}
+  .header-top{flex-direction:column;align-items:flex-start}
+  header .search{justify-content:flex-start}
+  #searchBox{width:100%}
+}
+
+main{display:grid;grid-template-columns:1fr 340px;gap:0;border-top:0}
+#reader{padding:1rem 1rem 4rem 1rem;max-width:920px}
 #textContainer{max-width: 860px}
 #textContainer p{margin:0.6rem 0;padding:0.2rem 0}
 #textContainer p:hover{background:#fafafa}
 
-#sidebar{border-left:1px solid #eee;height:calc(100vh - 56px);position:sticky;top:56px;padding:0.6rem 0.6rem 1rem 0.6rem;overflow:auto;background:#fcfcfc}
+#sidebar{border-left:1px solid #eee;height:calc(100vh - var(--header-height));position:sticky;top:var(--header-height);padding:0.6rem 0.6rem 1rem 0.6rem;overflow:auto;background:#fcfcfc}
 #sidebarHeader{display:flex;align-items:center;justify-content:space-between;border-bottom:1px solid #eee;padding-bottom:0.4rem;margin-bottom:0.6rem}
 #annotationView{font-size:0.95rem;white-space:pre-wrap}
 


### PR DESCRIPTION
## Summary
- add a Latest Works section beneath the landing search field to surface curated titles
- populate the list from app.js metadata, update navigation, and wire click handlers to open the reader
- refresh the landing layout styles, including responsive cards and sidebar offset tracking

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68db9fa6ef308329918c3760dbae8060