### PR TITLE
Add landing library selection screen before loading works

### DIFF
--- a/app.js
+++ b/app.js
@@ -168,6 +168,11 @@ async function loadText(work, options = {}) {
   landingSection.setAttribute('hidden', '');
   readerShell.removeAttribute('hidden');
   sidebar.style.display = 'block';
+  if (searchBox) {
+    searchBox.disabled = true;
+    searchBox.value = '';
+    searchBox.placeholder = 'Loading work…';
+  }
   textContainer.innerHTML = '<p class="loading">Loading work…</p>';
   try {
     const res = await fetch(work.src);
@@ -191,6 +196,11 @@ async function loadText(work, options = {}) {
     }
   } catch (err) {
     textContainer.innerHTML = '<p class="loading-error">Failed to load the selected work.</p>';
+    if (searchBox) {
+      searchBox.disabled = true;
+      searchBox.value = '';
+      searchBox.placeholder = 'Search in text…';
+    }
     alert('Failed to load text: ' + err.message);
   }
 }

--- a/app.js
+++ b/app.js
@@ -454,9 +454,24 @@ function openAnnotation(annId) {
 }
 
 closeSidebar.addEventListener('click', () => {
-  sidebar.style.display = 'block'; // keep layout but clear content
   annotationView.innerHTML = '<em>No annotation selected.</em>';
-  // do not clear hash to allow sharing
+  sidebar.style.display = 'none';
+  if (currentWork) {
+    updateUrlHash({ work: currentWork.id });
+  } else {
+    updateUrlHash({});
+  }
+});
+
+window.addEventListener('hashchange', () => {
+  if (!currentWork) return;
+  const { ann } = readHashParams();
+  if (ann) {
+    openAnnotation(ann);
+  } else {
+    annotationView.innerHTML = '<em>No annotation selected.</em>';
+    sidebar.style.display = 'none';
+  }
 });
 
 function restoreFromHash() {

--- a/app.js
+++ b/app.js
@@ -1,8 +1,12 @@
-// Simple Scholia-like annotator for a single work, storing annotations in localStorage.
+// Simple Scholia-like annotator that now supports a library of works.
 // Text is loaded from a plain UTF-8 file and split into paragraphs.
 const textContainer = document.getElementById('textContainer');
 const searchBox = document.getElementById('searchBox');
-const linkAntichrist = document.getElementById('link-antichrist');
+const worksSearch = document.getElementById('worksSearch');
+const worksList = document.getElementById('worksList');
+const landingSection = document.getElementById('landing');
+const readerShell = document.getElementById('readerShell');
+const libraryLink = document.getElementById('libraryLink');
 const sidebar = document.getElementById('sidebar');
 const closeSidebar = document.getElementById('closeSidebar');
 const annotationView = document.getElementById('annotationView');
@@ -14,11 +18,101 @@ const tooltip = document.getElementById('tooltip');
 const btnImport = document.getElementById('btn-import');
 const btnExport = document.getElementById('btn-export');
 
+const worksDirectory = [
+  {
+    id: 'antichrist',
+    title: 'Nietzsche — Der Antichrist',
+    src: 'antichrist_de_sample.txt',
+    description: 'Sample German excerpt'
+  }
+];
+
 let docParagraphs = []; // [{id, text}]
-let annotations = [];   // [{id, pid, start, end, exact, prefix, suffix, body, tags, createdAt}]
+let annotations = [];   // [{id, pid, start, end, exact, prefix, suffix, body, tags, createdAt, workId}]
+let currentWork = null;
 let currentSearchMatches = new Map(); // pid -> [{id, start, end}]
 
 const STORAGE_KEY = 'scholia_annotations_v1';
+
+function defaultWorkId() {
+  return worksDirectory[0] ? worksDirectory[0].id : null;
+}
+
+function annotationBelongsToCurrentWork(ann) {
+  if (!currentWork) return false;
+  const fallback = defaultWorkId();
+  const annWorkId = ann.workId || fallback;
+  return annWorkId === currentWork.id;
+}
+
+function renderWorksDirectory(filterText = '') {
+  if (!worksList) return;
+  const query = filterText.trim().toLowerCase();
+  const items = worksDirectory
+    .slice()
+    .sort((a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: 'base' }))
+    .filter(item => {
+      if (!query) return true;
+      const haystack = `${item.title} ${item.description || ''}`.toLowerCase();
+      return haystack.includes(query);
+    });
+
+  worksList.innerHTML = '';
+  if (!items.length) {
+    const li = document.createElement('li');
+    li.className = 'works-empty';
+    li.textContent = 'No works match your search.';
+    worksList.appendChild(li);
+    return;
+  }
+
+  items.forEach(item => {
+    const li = document.createElement('li');
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'work-link';
+    button.dataset.workId = item.id;
+    button.innerHTML = `
+      <span class="work-title">${escapeHtml(item.title)}</span>
+      ${item.description ? `<span class="work-meta">${escapeHtml(item.description)}</span>` : ''}
+    `;
+    li.appendChild(button);
+    worksList.appendChild(li);
+  });
+  updateActiveWorkIndicator();
+}
+
+function updateActiveWorkIndicator() {
+  if (!worksList) return;
+  const buttons = worksList.querySelectorAll('button[data-work-id]');
+  buttons.forEach(btn => {
+    const isActive = currentWork && btn.dataset.workId === currentWork.id;
+    btn.classList.toggle('is-active', isActive);
+  });
+}
+
+function showLanding(clearWork = false) {
+  document.body.classList.remove('is-reading');
+  landingSection.removeAttribute('hidden');
+  readerShell.setAttribute('hidden', '');
+  sidebar.style.display = 'none';
+  hideAnnotateToolbar();
+  tooltip.hidden = true;
+  if (clearWork) {
+    currentWork = null;
+    docParagraphs = [];
+    currentSearchMatches = new Map();
+    textContainer.innerHTML = '';
+    if (searchBox) {
+      searchBox.value = '';
+      searchBox.placeholder = 'Search in text…';
+      searchBox.disabled = true;
+    }
+    annotationView.innerHTML = '';
+  }
+  if (worksSearch) worksSearch.focus();
+  updateActiveWorkIndicator();
+}
 
 function loadAnnotations() {
   try {
@@ -32,20 +126,50 @@ function saveAnnotations() {
 
 function uid() { return 'a_' + Math.random().toString(36).slice(2,10) + Date.now().toString(36); }
 
-async function loadText(url) {
-  const res = await fetch(url);
-  const txt = await res.text();
-  // Split into paragraphs by blank lines
-  const paras = txt.split(/\n\s*\n/).map(s => s.trim()).filter(Boolean);
-  docParagraphs = paras.map((t, i) => ({ id: `p${i+1}`, text: t.replace(/\s+/g,' ').trim() }));
-  currentSearchMatches = new Map();
-  if (searchBox) searchBox.value = '';
-  renderText();
+async function loadText(work) {
+  if (!work) return;
+  document.body.classList.add('is-reading');
+  landingSection.setAttribute('hidden', '');
+  readerShell.removeAttribute('hidden');
+  sidebar.style.display = 'block';
+  textContainer.innerHTML = '<p class="loading">Loading work…</p>';
+  try {
+    const res = await fetch(work.src);
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    const txt = await res.text();
+    // Split into paragraphs by blank lines
+    const paras = txt.split(/\n\s*\n/).map(s => s.trim()).filter(Boolean);
+    docParagraphs = paras.map((t, i) => ({ id: `p${i+1}`, text: t.replace(/\s+/g,' ').trim() }));
+    currentWork = work;
+    currentSearchMatches = new Map();
+    if (searchBox) {
+      searchBox.disabled = false;
+      searchBox.value = '';
+      searchBox.placeholder = `Search in ${work.title}…`;
+    }
+    annotationView.innerHTML = '<em>No annotation selected.</em>';
+    renderText();
+    updateActiveWorkIndicator();
+  } catch (err) {
+    textContainer.innerHTML = '<p class="loading-error">Failed to load the selected work.</p>';
+    alert('Failed to load text: ' + err.message);
+  }
 }
 
 function renderText() {
+  if (!currentWork || !docParagraphs.length) {
+    if (!currentWork) {
+      textContainer.innerHTML = '<p class="empty-state">Choose a work from the library to start reading.</p>';
+    } else {
+      textContainer.innerHTML = '<p class="empty-state">No text available for this work.</p>';
+    }
+    tooltip.hidden = true;
+    return;
+  }
+
+  const relevantAnnotations = annotations.filter(annotationBelongsToCurrentWork);
   const annotationMap = new Map();
-  annotations.forEach(a => {
+  relevantAnnotations.forEach(a => {
     if (!annotationMap.has(a.pid)) annotationMap.set(a.pid, []);
     annotationMap.get(a.pid).push(a);
   });
@@ -177,6 +301,7 @@ function rangeToParagraphOffsets(range) {
 let pendingSelection = null;
 
 document.addEventListener('mouseup', (e) => {
+  if (!currentWork) return;
   const range = getSelectionWithin(textContainer);
   if (!range) { hideAnnotateToolbar(); return; }
   const rect = range.getBoundingClientRect();
@@ -199,7 +324,7 @@ function hideAnnotateToolbar() {
 
 annotateForm.addEventListener('submit', (e) => {
   e.preventDefault();
-  if (!pendingSelection) return;
+  if (!pendingSelection || !currentWork) return;
   const off = rangeToParagraphOffsets(pendingSelection);
   if (!off) { alert('Selection error. Try selecting within a single paragraph.'); return; }
   const ann = {
@@ -212,7 +337,8 @@ annotateForm.addEventListener('submit', (e) => {
     suffix: off.suffix,
     body: noteBody.value.trim(),
     tags: noteTags.value.split(',').map(s=>s.trim()).filter(Boolean),
-    createdAt: new Date().toISOString()
+    createdAt: new Date().toISOString(),
+    workId: currentWork.id
   };
   annotations.push(ann);
   saveAnnotations();
@@ -227,9 +353,10 @@ document.getElementById('cancelAnnotate').addEventListener('click', hideAnnotate
 
 // Hover tooltip and click to open
 textContainer.addEventListener('mouseover', (e) => {
+  if (!currentWork) { tooltip.hidden = true; return; }
   const span = e.target.closest('.annotation');
   if (!span) { tooltip.hidden = true; return; }
-  const ann = annotations.find(a => a.id === span.dataset.annId);
+  const ann = annotations.find(a => a.id === span.dataset.annId && annotationBelongsToCurrentWork(a));
   if (!ann) return;
   tooltip.textContent = ann.body.slice(0, 220);
   tooltip.hidden = false;
@@ -243,13 +370,15 @@ textContainer.addEventListener('mouseout', (e) => {
 });
 
 textContainer.addEventListener('click', (e) => {
+  if (!currentWork) return;
   const span = e.target.closest('.annotation');
   if (!span) return;
   openAnnotation(span.dataset.annId);
 });
 
 function openAnnotation(annId) {
-  const ann = annotations.find(a => a.id === annId);
+  if (!currentWork) return;
+  const ann = annotations.find(a => a.id === annId && annotationBelongsToCurrentWork(a));
   if (!ann) return;
   sidebar.style.display = 'block';
   annotationView.innerHTML = "";
@@ -285,6 +414,10 @@ function restoreFromHash() {
 
 // Search
 searchBox.addEventListener('input', () => {
+  if (!currentWork) {
+    searchBox.value = '';
+    return;
+  }
   const q = searchBox.value.trim();
   if (!q) {
     currentSearchMatches = new Map();
@@ -341,20 +474,36 @@ btnImport.addEventListener('click', async () => {
   input.click();
 });
 
+if (worksSearch) {
+  worksSearch.addEventListener('input', () => {
+    renderWorksDirectory(worksSearch.value);
+  });
+}
+
+if (worksList) {
+  worksList.addEventListener('click', (e) => {
+    const button = e.target.closest('button[data-work-id]');
+    if (!button) return;
+    e.preventDefault();
+    const work = worksDirectory.find(item => item.id === button.dataset.workId);
+    if (work) {
+      loadText(work);
+    }
+  });
+}
+
+if (libraryLink) {
+  libraryLink.addEventListener('click', (e) => {
+    e.preventDefault();
+    showLanding(!currentWork);
+  });
+}
+
 // Utility
 function escapeHtml(s){return s.replace(/[&<>"']/g, m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[m]))}
 
-// Load sample on click
-linkAntichrist.addEventListener('click', (e) => {
-  e.preventDefault();
-  loadText(linkAntichrist.dataset.src).catch(err => alert('Failed to load text: '+err.message));
-});
-
-// Auto-load on first visit
 window.addEventListener('DOMContentLoaded', () => {
   loadAnnotations();
-  const src = linkAntichrist.dataset.src; // e.g., "antichrist_de_sample.txt" in same folder as index.html
-  loadText(src).catch(err => {
-    textContainer.textContent = 'Failed to load the sample text. Place a public-domain text file alongside index.html and set the link.';
-  });
+  renderWorksDirectory();
+  showLanding(true);
 });

--- a/app.js
+++ b/app.js
@@ -38,6 +38,40 @@ function defaultWorkId() {
   return worksDirectory[0] ? worksDirectory[0].id : null;
 }
 
+function findWorkById(id) {
+  return worksDirectory.find(item => item.id === id);
+}
+
+function readHashParams() {
+  const hash = window.location.hash.startsWith('#')
+    ? window.location.hash.slice(1)
+    : window.location.hash;
+  if (!hash) return {};
+  const params = new URLSearchParams(hash);
+  const result = {};
+  params.forEach((value, key) => {
+    result[key] = value;
+  });
+  return result;
+}
+
+function updateUrlHash({ work, ann } = {}, { replace = true } = {}) {
+  const params = new URLSearchParams();
+  if (work) params.set('work', work);
+  if (ann) params.set('ann', ann);
+  const hashString = params.toString();
+  const newHash = hashString ? `#${hashString}` : '';
+  const target = `${window.location.pathname}${window.location.search}${newHash}`;
+  const method = replace ? 'replaceState' : 'pushState';
+  if (history && history[method]) {
+    history[method](null, '', target);
+  } else if (hashString) {
+    window.location.hash = newHash;
+  } else {
+    window.location.hash = '';
+  }
+}
+
 function annotationBelongsToCurrentWork(ann) {
   if (!currentWork) return false;
   const fallback = defaultWorkId();
@@ -109,6 +143,7 @@ function showLanding(clearWork = false) {
       searchBox.disabled = true;
     }
     annotationView.innerHTML = '';
+    updateUrlHash({});
   }
   if (worksSearch) worksSearch.focus();
   updateActiveWorkIndicator();
@@ -126,8 +161,9 @@ function saveAnnotations() {
 
 function uid() { return 'a_' + Math.random().toString(36).slice(2,10) + Date.now().toString(36); }
 
-async function loadText(work) {
+async function loadText(work, options = {}) {
   if (!work) return;
+  const { updateHash = false } = options;
   document.body.classList.add('is-reading');
   landingSection.setAttribute('hidden', '');
   readerShell.removeAttribute('hidden');
@@ -150,6 +186,9 @@ async function loadText(work) {
     annotationView.innerHTML = '<em>No annotation selected.</em>';
     renderText();
     updateActiveWorkIndicator();
+    if (updateHash) {
+      updateUrlHash({ work: work.id });
+    }
   } catch (err) {
     textContainer.innerHTML = '<p class="loading-error">Failed to load the selected work.</p>';
     alert('Failed to load text: ' + err.message);
@@ -393,12 +432,15 @@ function openAnnotation(annId) {
   const link = document.createElement('div');
   link.style.marginTop = '0.75rem';
   const url = new URL(window.location.href);
-  url.hash = `ann=${ann.id}`;
+  const linkParams = new URLSearchParams();
+  linkParams.set('work', currentWork.id);
+  linkParams.set('ann', ann.id);
+  url.hash = linkParams.toString();
   link.innerHTML = `<a href="${url.toString()}">Link to this annotation</a>`;
   annotationView.appendChild(header);
   annotationView.appendChild(body);
   annotationView.appendChild(link);
-  location.hash = `ann=${ann.id}`;
+  updateUrlHash({ work: currentWork.id, ann: ann.id });
 }
 
 closeSidebar.addEventListener('click', () => {
@@ -408,8 +450,8 @@ closeSidebar.addEventListener('click', () => {
 });
 
 function restoreFromHash() {
-  const m = location.hash.match(/ann=([A-Za-z0-9_]+)/);
-  if (m) openAnnotation(m[1]);
+  const { ann } = readHashParams();
+  if (ann) openAnnotation(ann);
 }
 
 // Search
@@ -487,7 +529,7 @@ if (worksList) {
     e.preventDefault();
     const work = worksDirectory.find(item => item.id === button.dataset.workId);
     if (work) {
-      loadText(work);
+      loadText(work, { updateHash: true });
     }
   });
 }
@@ -505,5 +547,21 @@ function escapeHtml(s){return s.replace(/[&<>"']/g, m=>({ '&':'&amp;','<':'&lt;'
 window.addEventListener('DOMContentLoaded', () => {
   loadAnnotations();
   renderWorksDirectory();
-  showLanding(true);
+  const params = readHashParams();
+  let workToLoad = null;
+  if (params.work) {
+    workToLoad = findWorkById(params.work);
+  } else if (params.ann) {
+    const ann = annotations.find(a => a.id === params.ann);
+    if (ann) {
+      const fallback = defaultWorkId();
+      const targetId = ann.workId || fallback;
+      workToLoad = findWorkById(targetId);
+    }
+  }
+  if (workToLoad) {
+    loadText(workToLoad);
+  } else {
+    showLanding(true);
+  }
 });

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
       <button id="btn-export" title="Export annotations JSON">Export</button>
     </nav>
     <div class="search" id="readerSearch">
-      <input type="search" id="searchBox" placeholder="Search in text…" aria-label="Search in text" />
+      <input type="search" id="searchBox" placeholder="Search in text…" aria-label="Search in text" disabled />
     </div>
   </header>
 

--- a/index.html
+++ b/index.html
@@ -3,33 +3,48 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Scholia — Nietzsche: Der Antichrist</title>
+  <title>Scholia — Reading Room</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <header>
     <div class="brand">Scholia</div>
     <nav>
-      <a href="#" id="link-antichrist" data-src="antichrist_de_sample.txt">Nietzsche — Der Antichrist</a>
+      <a href="#" id="libraryLink">Library</a>
       <button id="btn-import" title="Import annotations JSON">Import</button>
       <button id="btn-export" title="Export annotations JSON">Export</button>
     </nav>
-    <div class="search">
-      <input type="search" id="searchBox" placeholder="Search in text…" aria-label="Search in text"/>
+    <div class="search" id="readerSearch">
+      <input type="search" id="searchBox" placeholder="Search in text…" aria-label="Search in text" />
     </div>
   </header>
 
   <main>
-    <section id="reader">
-      <div id="textContainer" aria-live="polite"></div>
-    </section>
-    <aside id="sidebar" aria-label="Annotations panel">
-      <div id="sidebarHeader">
-        <h2>Annotation</h2>
-        <button id="closeSidebar" aria-label="Close">×</button>
+    <section id="landing" aria-labelledby="landingTitle">
+      <div class="landing-inner">
+        <h1 id="landingTitle">Reading Room</h1>
+        <p class="landing-tagline">Browse the public-domain collection and open a work to begin annotating.</p>
+        <div class="landing-search">
+          <input type="search" id="worksSearch" placeholder="Search works by title…" aria-label="Search works" />
+        </div>
+        <nav class="works-directory" aria-label="Available works">
+          <ul id="worksList" class="works-list"></ul>
+        </nav>
       </div>
-      <div id="annotationView"></div>
-    </aside>
+    </section>
+
+    <section id="readerShell" hidden>
+      <section id="reader">
+        <div id="textContainer" aria-live="polite"></div>
+      </section>
+      <aside id="sidebar" aria-label="Annotations panel">
+        <div id="sidebarHeader">
+          <h2>Annotation</h2>
+          <button id="closeSidebar" aria-label="Close">×</button>
+        </div>
+        <div id="annotationView"></div>
+      </aside>
+    </section>
   </main>
 
   <div id="annotateToolbar" role="dialog" aria-modal="false">
@@ -50,7 +65,7 @@
   <footer>
     <p>
       Text loader expects a public-domain source. This demo ships with a short German sample.
-      For a full edition, place a public-domain text file alongside <code>index.html</code> and update the link.
+      For a full edition, place a public-domain text file alongside <code>index.html</code> and update the library entry.
     </p>
   </footer>
 

--- a/styles.css
+++ b/styles.css
@@ -31,6 +31,13 @@ body:not(.is-reading) #readerSearch { display: none; }
   border: 1px solid #ccc;
   border-radius: 6px;
 }
+#searchBox:disabled {
+  background: #f5f5f5;
+  color: #777;
+  cursor: not-allowed;
+  border-color: #ddd;
+  box-shadow: none;
+}
 
 main {
   padding: 1.5rem 1rem;

--- a/styles.css
+++ b/styles.css
@@ -1,32 +1,225 @@
-*{box-sizing:border-box}html,body{margin:0;padding:0}
-body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Arial,sans-serif;line-height:1.55}
-header{display:flex;gap:1rem;align-items:center;justify-content:space-between;padding:0.6rem 1rem;border-bottom:1px solid #ddd;position:sticky;top:0;background:#fff;z-index:10}
-.brand{font-weight:700}
-nav{display:flex;gap:0.6rem;align-items:center}
-nav a{color:#0a5; text-decoration:none; font-weight:600}
-nav a:hover{text-decoration:underline}
-header .search{flex:1;display:flex;justify-content:flex-end}
-#searchBox{width:min(520px,80vw);padding:0.45rem 0.6rem;border:1px solid #ccc;border-radius:6px}
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Arial, sans-serif;
+  line-height: 1.55;
+}
 
-main{display:grid;grid-template-columns: 1fr 340px;gap:0;border-top:0}
-#reader{padding:1rem 1rem 4rem 1rem;max-width: 920px}
-#textContainer{max-width: 860px}
-#textContainer p{margin:0.6rem 0;padding:0.2rem 0}
-#textContainer p:hover{background:#fafafa}
+[hidden] { display: none !important; }
 
-#sidebar{border-left:1px solid #eee;height:calc(100vh - 56px);position:sticky;top:56px;padding:0.6rem 0.6rem 1rem 0.6rem;overflow:auto;background:#fcfcfc}
-#sidebarHeader{display:flex;align-items:center;justify-content:space-between;border-bottom:1px solid #eee;padding-bottom:0.4rem;margin-bottom:0.6rem}
-#annotationView{font-size:0.95rem;white-space:pre-wrap}
+header {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 1rem;
+  border-bottom: 1px solid #ddd;
+  position: sticky;
+  top: 0;
+  background: #fff;
+  z-index: 10;
+}
+.brand { font-weight: 700; }
+nav { display: flex; gap: 0.6rem; align-items: center; }
+nav a { color: #0a5; text-decoration: none; font-weight: 600; }
+nav a:hover { text-decoration: underline; }
+header .search { flex: 1; display: flex; justify-content: flex-end; }
+body:not(.is-reading) #readerSearch { display: none; }
+#searchBox {
+  width: min(520px, 80vw);
+  padding: 0.45rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+}
 
-.annotation{background: #fff3ac; border-bottom: 1px dotted #b48c00; cursor: pointer; padding: 0 1px}
-.annotation:hover{background:#ffe88a}
-mark.searchHit{background:#b3e5fc;color:inherit;padding:0 1px;border-radius:2px}
+main {
+  padding: 1.5rem 1rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+body.is-reading main {
+  padding: 0;
+  max-width: none;
+}
 
-#annotateToolbar{position:absolute; background:#fff; border:1px solid #ddd; border-radius:8px; padding:0.5rem; box-shadow:0 8px 24px rgba(0,0,0,.1); width:min(420px,92vw); display:none; z-index:20}
-#annotateToolbar textarea, #annotateToolbar input{width:100%; margin:0.25rem 0}
-#annotateToolbar .row{display:flex; gap:0.5rem; align-items:center; justify-content:flex-end}
+#landing {
+  padding: 3rem 0;
+}
+.landing-inner {
+  max-width: 720px;
+  margin: 0 auto;
+  text-align: center;
+}
+.landing-inner h1 {
+  font-size: 2.5rem;
+  margin-bottom: 0.25rem;
+}
+.landing-tagline {
+  color: #555;
+  margin: 0 auto 1.5rem auto;
+  max-width: 540px;
+}
+.landing-search { margin-bottom: 2rem; }
+.landing-search input {
+  width: min(540px, 90vw);
+  padding: 0.85rem 1.1rem;
+  font-size: 1.1rem;
+  border: 1px solid #bbb;
+  border-radius: 999px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.06);
+}
+.works-directory {
+  margin: 0 auto;
+  max-width: 620px;
+  text-align: left;
+}
+.works-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.works-list li { margin: 0; }
+.work-link {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border: 1px solid #d7d7d7;
+  border-radius: 10px;
+  background: #fff;
+  text-align: left;
+  font-size: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+  cursor: pointer;
+}
+.work-link:hover,
+.work-link:focus {
+  border-color: #0a5;
+  box-shadow: 0 12px 28px rgba(0, 160, 80, 0.12);
+  outline: none;
+}
+.work-link .work-title { font-weight: 600; }
+.work-link .work-meta { font-size: 0.9rem; color: #555; }
+.work-link.is-active {
+  border-color: #0a5;
+  background: #f1fff6;
+  box-shadow: 0 10px 24px rgba(0, 160, 80, 0.14);
+}
+.works-empty {
+  padding: 1rem 1.2rem;
+  border: 1px dashed #ccc;
+  border-radius: 10px;
+  text-align: center;
+  color: #666;
+  font-style: italic;
+}
 
-#tooltip{position:absolute; background:#222; color:#fff; font-size:12px; padding:6px 8px; border-radius:6px; max-width: 360px; z-index:30}
+#readerShell { display: none; }
+body.is-reading #readerShell {
+  display: grid;
+  grid-template-columns: 1fr 340px;
+  gap: 0;
+  border-top: 0;
+}
+#reader {
+  padding: 1rem 1rem 4rem 1rem;
+  max-width: 920px;
+}
+#textContainer { max-width: 860px; }
+#textContainer p {
+  margin: 0.6rem 0;
+  padding: 0.2rem 0;
+}
+#textContainer p:hover { background: #fafafa; }
 
-footer{border-top:1px solid #eee;padding:0.6rem 1rem;color:#666;font-size:0.9rem}
-button{cursor:pointer}
+body:not(.is-reading) #sidebar { display: none; }
+#sidebar {
+  border-left: 1px solid #eee;
+  height: calc(100vh - 56px);
+  position: sticky;
+  top: 56px;
+  padding: 0.6rem 0.6rem 1rem 0.6rem;
+  overflow: auto;
+  background: #fcfcfc;
+}
+#sidebarHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 0.4rem;
+  margin-bottom: 0.6rem;
+}
+#annotationView { font-size: 0.95rem; white-space: pre-wrap; }
+
+.annotation {
+  background: #fff3ac;
+  border-bottom: 1px dotted #b48c00;
+  cursor: pointer;
+  padding: 0 1px;
+}
+.annotation:hover { background: #ffe88a; }
+mark.searchHit {
+  background: #b3e5fc;
+  color: inherit;
+  padding: 0 1px;
+  border-radius: 2px;
+}
+
+.empty-state,
+.loading,
+.loading-error {
+  margin: 2rem auto;
+  font-size: 1rem;
+  color: #555;
+  text-align: center;
+  max-width: 560px;
+}
+.loading { color: #0a5; }
+.loading-error { color: #c00; }
+
+#annotateToolbar {
+  position: absolute;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 0.5rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+  width: min(420px, 92vw);
+  display: none;
+  z-index: 20;
+}
+#annotateToolbar textarea,
+#annotateToolbar input {
+  width: 100%;
+  margin: 0.25rem 0;
+}
+#annotateToolbar .row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+#tooltip {
+  position: absolute;
+  background: #222;
+  color: #fff;
+  font-size: 12px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  max-width: 360px;
+  z-index: 30;
+}
+
+footer {
+  border-top: 1px solid #eee;
+  padding: 0.6rem 1rem;
+  color: #666;
+  font-size: 0.9rem;
+}
+button { cursor: pointer; }


### PR DESCRIPTION
## Summary
- replace the one-column reader layout with a landing library that lists available works and a deferred reader shell
- update the app logic to render the library, filter works via search, and load reader content only after a selection
- refresh styling to support the landing layout while retaining the existing typography classes

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68db9fa2a1bc832994988fd915cb675d