### PR TITLE
Disable text search until a work loads

### DIFF
--- a/app.js
+++ b/app.js
@@ -168,6 +168,11 @@ async function loadText(work, options = {}) {
   landingSection.setAttribute('hidden', '');
   readerShell.removeAttribute('hidden');
   sidebar.style.display = 'block';
+  if (searchBox) {
+    searchBox.disabled = true;
+    searchBox.value = '';
+    searchBox.placeholder = 'Loading work…';
+  }
   textContainer.innerHTML = '<p class="loading">Loading work…</p>';
   try {
     const res = await fetch(work.src);
@@ -191,6 +196,11 @@ async function loadText(work, options = {}) {
     }
   } catch (err) {
     textContainer.innerHTML = '<p class="loading-error">Failed to load the selected work.</p>';
+    if (searchBox) {
+      searchBox.disabled = true;
+      searchBox.value = '';
+      searchBox.placeholder = 'Search in text…';
+    }
     alert('Failed to load text: ' + err.message);
   }
 }

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
       <button id="btn-export" title="Export annotations JSON">Export</button>
     </nav>
     <div class="search" id="readerSearch">
-      <input type="search" id="searchBox" placeholder="Search in text…" aria-label="Search in text" />
+      <input type="search" id="searchBox" placeholder="Search in text…" aria-label="Search in text" disabled />
     </div>
   </header>
 

--- a/styles.css
+++ b/styles.css
@@ -31,6 +31,13 @@ body:not(.is-reading) #readerSearch { display: none; }
   border: 1px solid #ccc;
   border-radius: 6px;
 }
+#searchBox:disabled {
+  background: #f5f5f5;
+  color: #777;
+  cursor: not-allowed;
+  border-color: #ddd;
+  box-shadow: none;
+}
 
 main {
   padding: 1.5rem 1rem;


### PR DESCRIPTION
## Summary
- disable the reader search box until a work is available and show a loading placeholder while fetching
- restore the default disabled state if the fetch fails and initialize the input as disabled in the markup
- style the disabled search field so its inactive state is visible

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbb0cd65f8832982df37a957976f4b