### PR TITLE
Fix annotation sidebar closing behavior

### DIFF
--- a/app.js
+++ b/app.js
@@ -454,9 +454,24 @@ function openAnnotation(annId) {
 }
 
 closeSidebar.addEventListener('click', () => {
-  sidebar.style.display = 'block'; // keep layout but clear content
   annotationView.innerHTML = '<em>No annotation selected.</em>';
-  // do not clear hash to allow sharing
+  sidebar.style.display = 'none';
+  if (currentWork) {
+    updateUrlHash({ work: currentWork.id });
+  } else {
+    updateUrlHash({});
+  }
+});
+
+window.addEventListener('hashchange', () => {
+  if (!currentWork) return;
+  const { ann } = readHashParams();
+  if (ann) {
+    openAnnotation(ann);
+  } else {
+    annotationView.innerHTML = '<em>No annotation selected.</em>';
+    sidebar.style.display = 'none';
+  }
 });
 
 function restoreFromHash() {


### PR DESCRIPTION
## Summary
- hide the annotation sidebar when the close button is pressed and clear the selected annotation state
- keep the work hash while removing the annotation parameter to avoid stale links
- react to hash changes by reopening annotations or hiding the sidebar as needed

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbb2f304f48329ae934b04388d24b2